### PR TITLE
Be less agressive on numba version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pynndescent >= 0.4.5
 umap-learn >= 0.4.2
 hdbscan >= 0.8.22
 enstop >= 0.1.6
-numba >= 0.49
+numba >= 0.48
 spacy

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ INSTALL_REQUIRES = [
     "numpy",
     "scipy",
     "scikit-learn",
-    "numba >= 0.49",
+    "numba >= 0.48",
     "enstop >= 0.1.6",
     "umap-learn >= 0.4.2",
     "pynndescent >= 0.4.5",


### PR DESCRIPTION
numba >=0.49  conflicts with datashader 0.11'a (numba < 0.49). Datashader is required by umap[plot]